### PR TITLE
Update the copyright year

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -49,7 +49,7 @@ function toggleMenu() {
 }
 
 // toggle TOC
-document.querySelector("#toggleTOC").addEventListener("click", toggleTOC);
+document.querySelector("#toggleTOC")?.addEventListener("click", toggleTOC);
 
 function toggleTOC() {
   document.querySelector("#TOC").classList.toggle("hidden");
@@ -80,4 +80,15 @@ iframes.forEach((iframe) => {
       });
     });
   });
+});
+
+//a function to get the current year
+function getCurrentYear() {
+  return new Date()?.getFullYear();
+}
+
+//update the copyright year automatically
+const yearSpans = document.querySelectorAll("span.year");
+yearSpans.forEach((yearSpan) => {
+  yearSpan.innerText = getCurrentYear();
 });

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -49,7 +49,7 @@
           </div>
           <footer class="mt-10">
             <div class="container mx-auto">
-              <div class="border-t py-10 text-center">Copyright © 2022 Sailboat UI</div>
+              <div class="border-t py-10 text-center">Copyright © <span class="year"></span> Sailboat UI</div>
             </div>
           </footer>
         </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer>
   <div class="container mx-auto px-6 2xl:px-32">
-    <div class="border-t py-10 text-center">Copyright © 2022 Sailboat UI</div>
+    <div class="border-t py-10 text-center">Copyright © <span class="year"></span> Sailboat UI</div>
   </div>
 </footer>


### PR DESCRIPTION
This functionality update the copyright year automatically removing the need for manual edits. I also had an issue with the line of code below in `assets/js/app.js`

When like this it is throwing a Type error,  when you are on the `Home` page of the site, but not the `/docs` routes.
```js
// toggle TOC
document.querySelector("#toggleTOC").addEventListener("click", toggleTOC);
```

To fix the above issue I added the `?.` operator, to short-circuit when the value is null
```js
// toggle TOC
document.querySelector("#toggleTOC").addEventListener("click", toggleTOC);
```
